### PR TITLE
🔖 [add] content collection

### DIFF
--- a/src/components/meta/Head.astro
+++ b/src/components/meta/Head.astro
@@ -1,4 +1,5 @@
 ---
+import { ViewTransitions } from 'astro:transitions';
 export interface Props {
     title?: string;
 }
@@ -14,6 +15,8 @@ const { title } = Astro.props
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Epilogue:wght@400;600;700&display=swap" rel="stylesheet">
+
+    <ViewTransitions/>
 
     <title>{title}</title>
 </head>

--- a/src/content/blog/blog-post-1.md
+++ b/src/content/blog/blog-post-1.md
@@ -1,0 +1,13 @@
+---
+title: Blog Post 1
+author: Mijane
+date: 2023-11-12
+tags: 
+    - software
+    - marketing
+---
+
+
+##### entrypoint
+
+This is my first blog post. Everything has a start. This is a seed

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,0 +1,38 @@
+import { defineCollection, z } from "astro:content";
+
+const blog = defineCollection({
+    type: 'content',
+    schema: z.object({
+        title: z.string(),
+        author: z.string(),
+        date: z.coerce.date(),
+        tags: z.array(z.string())
+    })
+})
+
+const library = defineCollection({
+    type: 'content',
+    schema: z.object({
+        title: z.string(),
+        author: z.string(),
+        rating: z.number(),
+        finished: z.boolean()
+    })
+})
+
+const projects = defineCollection({
+    type: 'content',
+    schema: z.object({
+        title: z.string(),
+        description: z.string(),
+        tags: z.array(z.string()),
+        demo: z.string(),
+        completed: z.boolean()
+    })
+})
+
+export const collections = {
+    'blog': blog,
+    'library': library,
+    'projects': projects
+}

--- a/src/content/library/the-creative-act.md
+++ b/src/content/library/the-creative-act.md
@@ -1,0 +1,10 @@
+---
+title: The Creative Act
+author: Rick Rubin
+rating: 4
+finished: true 
+---
+
+![Book Cover](https://cdn.kobo.com/book-images/1f302202-115c-420c-abfa-10e0cb0f3885/353/569/90/False/the-creative-act.jpg)
+
+> Even with the greatest work, It's natural for excitement to wax and wane\n

--- a/src/content/library/zero-to-one.md
+++ b/src/content/library/zero-to-one.md
@@ -1,0 +1,10 @@
+---
+title: Zero to One
+author: Peter Thiel
+rating: 4
+finished: true 
+---
+
+![Book Cover](https://cdn.kobo.com/book-images/8ac7fd3a-b91f-4ed2-9633-3b46efe99905/1200/1200/False/zero-to-one-2.jpg)
+
+> if you build something valuable where there was nothing before, the increase in value is theoretically infinite

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,1 +1,2 @@
+/// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -10,6 +10,8 @@ import "../styles/global.css"
     <Head title={garden.site.title}/>
     <body class="bg-slate-50 text-rust-grey dark:bg-rust-grey dark:text-willow-grey font-epiloge">
         <Navbar/>
-        <slot/>
+        <div id="container">
+            <slot/>
+        </div>
     </body>
 </html>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,0 +1,21 @@
+---
+import type { GetStaticPaths } from "astro";
+import { getCollection } from "astro:content";
+import Base from "@layouts/Base.astro";
+
+export async function getStaticPaths() {
+    const entries = await getCollection('blog');
+
+    return entries.map(entry => ({
+        params: { slug: entry.slug }, props: { entry }
+    }))
+}
+
+const { entry } = Astro.props;
+const { Content } = await entry.render()
+---
+
+<Base>
+    <h1>{entry.data.title}</h1>
+    <Content />
+</Base>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,9 +1,21 @@
 ---
+import { getCollection } from "astro:content";
 import Base from "../../layouts/Base.astro"
+
+const posts = await getCollection('blog')
 ---
 
 <Base>
     <div class="container">
         Blog
+        <ul>
+            {
+                posts.map(post => (
+                    <li>
+                        <a href={`blog/${post.slug}`}>{post.data.title}</a>
+                    </li>
+                ))
+            }
+        </ul>
     </div>
 </Base>

--- a/src/pages/library/index.astro
+++ b/src/pages/library/index.astro
@@ -1,9 +1,22 @@
 ---
+import { getCollection } from "astro:content";
 import Base from "../../layouts/Base.astro"
+
+const books = await getCollection('library')
 ---
 
 <Base>
     <div class="container">
         Library
+
+        {
+            books.map(book => (
+                <li>
+                    <a href={book.slug}>
+                        {book.data.title}    
+                    </a>
+                </li>
+            ))
+        }
     </div>
 </Base>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -30,7 +30,6 @@
   @apply stroke-zinc-200;
 }
 
-
-.container {
+#container {
   @apply max-w-screen-xl mx-auto p-3;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "astro/tsconfigs/strict",
   "compilerOptions": {
+    "strictNullChecks": true,
     "baseUrl": ".",
     "paths": {
       "@components/*": ["./src/components/*"],


### PR DESCRIPTION
### content collections
for static output site generation. contents are located inside the content/ folder. the config is found in config.ts. for further configuration refer to [astro collection docs](https://docs.astro.build/en/guides/content-collections/)

#### imports
astro:content
view transitions api

#### files
added sample markdown files with dummy content inside blog, library, and projects folder.

#### etc
- some changes in the base layout. Added a container id with tailwind apply directive. `#container` is declared inside `src/styles/global.css`
- appllied view transitions in meta component Head.astro